### PR TITLE
Lf 38726 reduce size of exported qt svgs

### DIFF
--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -122,6 +122,7 @@ public:
     bool      pathsMergeable;
     QString   currentPathContents;
     int       gSize;
+    QString   previousGState;
 
     QBrush brush;
     QPen pen;
@@ -1107,12 +1108,12 @@ void QSvgPaintEngine::updateState(const QPaintEngineState &state)
                     clip_path_to_id[clip_path] = clip_counter++;
 
                 d->currentClipID = clip_path_to_id[clip_path];
-                
-                out.setString(&d->currentClipString, QIODevice::Append);
+                d->stream->setString(&d->currentClipString, QIODevice::Append);
+                *d->stream << "<clipPath id=\"clip" << clip_path_to_id[clip_path] << "\">" << endl;
+                *d->stream << '\t' << clip_path;
+                *d->stream << "</clipPath>" << endl;
 
-                out << "<clipPath id=\"clip" << clip_path_to_id[clip_path] << "\">" << endl;
-                out << '\t' << clip_path;
-                out << "</clipPath>" << endl;
+                d->stream->setString(&newGState, QIODevice::Append);
             }
 
             *d->stream << "clip-path=\"url(#clip" << clip_path_to_id[clip_path] << ")\" ";

--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -1165,14 +1165,14 @@ void QSvgPaintEngine::updateState(const QPaintEngineState &state)
         d->currentBody.clear();  // we are now discarding the old state completely
 
         // close old state and start a new one...
-        d->stream->setString(d->currentBody, QIODevice::Append);
+        d->stream->setString(&d->currentBody, QIODevice::Append);
         if (afterFirstUpdate)
             *d->stream << "</g>\n\n";
         *d->stream << newGState;
         d->previousGState = newGState;
         d->gSize = d->currentBody.size(); 
     } else {
-        d->stream->setString(d->currentBody, QIODevice::Append);
+        d->stream->setString(&d->currentBody, QIODevice::Append);
     }
 }
 

--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -661,14 +661,16 @@ public:
 
         d->currentClipString.clear();  // We will always overwrite or blank this
 
-        if (!clippingEnabled || clipPath.isEmpty())      
+        if (!clippingEnabled || clipPath.isEmpty()) {
             return;  // Nothing to do
+        }    
 
         QString pathElement = pathDataToSvg(qPainterPathToPathData(clipPath), clipPath.fillRule(), pen);
 
         bool path_does_not_exist = 0 == clip_path_to_id.count(pathElement);
-        if (path_does_not_exist)
+        if (path_does_not_exist) {
             clip_path_to_id[pathElement] = clip_counter++;  // Create a new clip ID for this path
+        }
         d->currentClipID = clip_path_to_id[pathElement];
 
         bool path_never_saved = path_does_not_exist || !d->savedClipIDs.contains(d->currentClipID);
@@ -1239,8 +1241,9 @@ void QSvgPaintEngine::drawPath(const QPainterPath &p)
 {
     Q_D(QSvgPaintEngine);
 
-    if (p.isEmpty())
+    if (p.isEmpty()) {
         return;
+    }
 
     QString pathData = qPainterPathToPathData(p);
     QTextStream out(&d->currentPathContents, QIODevice::Append);

--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -463,6 +463,7 @@ public:
     void qbrushToSvg(const QBrush &sbrush)
     {
         d_func()->brush = sbrush;
+        d_func()->pathsMergeable = false;
         switch (sbrush.style()) {
         case Qt::SolidPattern: {
             QString color, colorOpacity;
@@ -518,10 +519,11 @@ public:
             stream() << QLatin1String("fill=\"none\" ");
             d_func()->attributes.fill = QLatin1String("none");
             d_func()->attributes.fillOpacity = QString();
+            d_func()->pathsMergeable = true;  // with no fill, we can squash paths together not caring about the Qt::FillRule in use
             return;
             break;
         default:
-           break;
+            break;
         }
     }
     void qfontToSvg(const QFont &sfont)
@@ -1123,7 +1125,6 @@ void QSvgPaintEngine::updateState(const QPaintEngineState &state)
 
     if (flags & QPaintEngine::DirtyBrush) {
         qbrushToSvg(state.brush());
-        d->pathsMergeable = d_func()->attributes.fill == QLatin1String("none");  // paths are unfilled so can be squashed into one tag
     }
 
     if (flags & QPaintEngine::DirtyPen) {

--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -675,7 +675,7 @@ public:
 
         bool path_never_saved = path_does_not_exist || !d->savedClipIDs.contains(d->currentClipID);
         if (path_never_saved) {  // Either a never-seen clip, or a clip that was chucked when the g state was discarded
-            d->currentClipString = QString("<clipPath id=\"clip%1\">\n\t%2</clipPath>\n").arg(d->currentClipID, pathElement);
+            d->currentClipString = QString("<clipPath id=\"clip%1\">\n\t%2</clipPath>\n").arg(d->currentClipID).arg(pathElement);
         }
 
         *d->stream << "clip-path=\"url(#clip" << d->currentClipID << ")\" ";

--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -1185,6 +1185,10 @@ void QSvgPaintEngine::drawEllipse(const QRectF &r)
 void QSvgPaintEngine::drawPath(const QPainterPath &p)
 {
     Q_D(QSvgPaintEngine);
+
+    if (p.isEmpty())
+        return;
+
     QString pathData = qPainterPathToPathData(p);
     QTextStream out(&d->currentPathContents, QIODevice::Append);
     if (d->pathsMergeable) {

--- a/src/svg/qsvggenerator.cpp
+++ b/src/svg/qsvggenerator.cpp
@@ -520,10 +520,14 @@ public:
             d_func()->attributes.fill = QLatin1String("none");
             d_func()->attributes.fillOpacity = QString();
             d_func()->pathsMergeable = true;  // with no fill, we can squash paths together not caring about the Qt::FillRule in use
-            return;
             break;
         default:
             break;
+        }
+        if (d_func()->pathsMergeable) {
+            qDebug("qbrushToSvg: merging paths");
+        } else {
+            qDebug("qbrushToSvg: NOT merging paths");
         }
     }
     void qfontToSvg(const QFont &sfont)
@@ -1074,8 +1078,10 @@ void QSvgPaintEngine::updateState(const QPaintEngineState &state)
         *d->stream << d->currentBody;
         d->currentBody.clear();
         if (d->pathsMergeable) {
+            qDebug("QSvgPaintEngine::updateState: merging paths");
             *d->stream << pathDataToSvg(d->currentPathContents, Qt::OddEvenFill);  // fillRule doesn't matter, no fill is actually set
         } else {
+            qDebug("QSvgPaintEngine::updateState: NOT merging paths");
             *d->stream << d->currentPathContents;  // tags are already fully written
         }
         d->currentPathContents.clear();
@@ -1197,7 +1203,9 @@ void QSvgPaintEngine::drawPath(const QPainterPath &p)
         if (!d->currentPathContents.isEmpty())
             out << " ";
         out << pathData;  // Just append data portion
+        qDebug("QSvgPaintEngine::drawPath: merging paths");
     } else {
+        qDebug("QSvgPaintEngine::drawPath: NOT merging paths");
         out << pathDataToSvg(pathData, p.fillRule());  // Output whole tag
     }
 }


### PR DESCRIPTION
Pretty extensive refactoring of the QSvgGenerator to achieve 5 goals:

1. Not writing out a whole load of empty g tags
2. Not writing out a whole load of consecutive g tags with the exact same states
3. Only writing clipPaths to the defs when they are actually used by a kept g tag
4. Removing the 'qt defaults' parent g tag, which is always useless as every g tag has the complete state set
5. Merging path elements where they are contained in a g tag with no fill, which saves space and renders quicker, without having problems changing z order (since everything drawn within that g will just be a line of the same colour)

This is achieved by keeping better track of the current state, allowing only streaming it to the output when required.